### PR TITLE
Bump minimal PHP version to 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"stan": "vendor/bin/phpstan analyse --level 7 src"
 	},
 	"require": {
-		"php": "^7.1",
+		"php": "^7.2",
 		"symfony/messenger": "^5.0",
 		"nette/di": "^3.0",
 		"nette/schema": "^1.0",


### PR DESCRIPTION
It's currently lowest version supported by `symfony/messenger`, so this package cannot be installed on 7.1 anyway.