### PR TITLE
PHP 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.4', '8.0']
         composer-flags: ['', '--prefer-lowest --prefer-stable']
     name: PHP ${{ matrix.php-versions }} tests | ${{ matrix.composer-flags }}
     steps:
@@ -48,7 +48,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
           coverage: xdebug
 
       - name: Cache/Restore dependencies
@@ -57,8 +57,8 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: php-7.4
-          restore-keys: php-7.4
+          key: php-8.0
+          restore-keys: php-8.0
 
       - name: Install Dependencies
         run: composer update --no-interaction --prefer-dist
@@ -83,7 +83,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
 
       - name: Cache/Restore dependencies
         uses: actions/cache@v2
@@ -91,8 +91,8 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: php-7.4
-          restore-keys: php-7.4
+          key: php-8.0
+          restore-keys: php-8.0
 
       - name: Install Dependencies
         run: composer update --no-interaction --prefer-dist
@@ -110,7 +110,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
 
       - name: Cache/Restore dependencies
         uses: actions/cache@v2
@@ -118,8 +118,8 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: php-7.4
-          restore-keys: php-7.4
+          key: php-8.0
+          restore-keys: php-8.0
 
       - name: Install Dependencies
         run: composer update --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
 		"psr/container": "^1.0",
 		"symfony/event-dispatcher": "^4.4|^5.0",
 		"symfony/messenger": "^5.1",
+		"symfony/console": "^4.4|^5.0",
 		"nette/di": "^3.0.1",
 		"nette/schema": "^1.0",
 		"tracy/tracy": "^2.6"

--- a/composer.json
+++ b/composer.json
@@ -14,22 +14,21 @@
 		"stan": "vendor/bin/phpstan analyse --level 7 src"
 	},
 	"require": {
-		"php": "^7.2",
+		"php": "^7.4 || ^8.0",
 		"psr/container": "^1.0",
 		"symfony/event-dispatcher": "^4.4|^5.0",
 		"symfony/messenger": "^5.1",
 		"symfony/console": "^4.4|^5.0",
 		"nette/di": "^3.0.1",
-		"nette/schema": "^1.0",
+		"nette/schema": "^1.0.3",
 		"tracy/tracy": "^2.6"
 	},
 	"require-dev": {
 		"mockery/mockery": "^1.2",
-		"phpunit/phpunit": "^6.5",
-		"phpunit/phpcov": "^4.0",
+		"phpunit/phpunit": "^9.5",
 		"nette/bootstrap": "^3.0",
 		"phpstan/phpstan": "^0.12",
-		"doctrine/coding-standard": "^6.0"
+		"doctrine/coding-standard": "^8.1"
 	},
 	"authors": [
 		{

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
     ignoreErrors:
-        - "~Parameter #1 \\$argument of class ReflectionClass constructor expects class-string<T of object>\\|T of object, string given.~"
-        - "~Parameter #1 \\$function of function call_user_func expects callable\\(\\): mixed, array\\(string, 'getHandledMessages'\\) given\\.~"
+        - "~Parameter #1 \\$objectOrClass of class ReflectionClass constructor expects class-string<T of object>\\|T of object, string given.~"
+        - "~Parameter #1 \\$callback of function call_user_func expects callable\\(\\): mixed, array\\(string, 'getHandledMessages'\\) given\\.~"
         - '~Cannot access property (\$buses|\$transports|\$routing|\$serializer) on array\|object.~'

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Fmasa/Messenger
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/fmasa/messenger/main)
 [![Coverage Status](https://coveralls.io/repos/github/fmasa/messenger/badge.svg?branch=master)](https://coveralls.io/github/fmasa/messenger?branch=master)
 
-PHP 7.1+ integration of [Symfony/Messenger](https://symfony.com/doc/current/messenger.html) to Nette Framework
+PHP 7.4+ integration of [Symfony/Messenger](https://symfony.com/doc/current/messenger.html) to Nette Framework
 
 ## Installation
 

--- a/src/Messenger/DI/BusConfig.php
+++ b/src/Messenger/DI/BusConfig.php
@@ -11,15 +11,12 @@ use Nette\DI\Statement;
  */
 final class BusConfig
 {
-    /** @var bool */
-    public $allowNoHandlers = false;
+    public bool $allowNoHandlers = false;
 
-    /** @var bool */
-    public $singleHandlerPerMessage = false;
+    public bool $singleHandlerPerMessage = false;
 
     /** @var Statement[] */
-    public $middleware = [];
+    public array $middleware = [];
 
-    /** @var bool */
-    public $panel = true;
+    public bool $panel = true;
 }

--- a/src/Messenger/DI/MessengerExtension.php
+++ b/src/Messenger/DI/MessengerExtension.php
@@ -36,6 +36,7 @@ use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Transport\InMemoryTransportFactory;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactory;
+
 use function array_filter;
 use function array_keys;
 use function array_map;
@@ -63,7 +64,7 @@ class MessengerExtension extends CompilerExtension
         'redis' => RedisTransportFactory::class,
     ];
 
-    public function getConfigSchema() : Schema
+    public function getConfigSchema(): Schema
     {
         return Expect::structure([
             'serializer' => Expect::from(new SerializerConfig()),
@@ -78,7 +79,7 @@ class MessengerExtension extends CompilerExtension
         ]);
     }
 
-    public function loadConfiguration() : void
+    public function loadConfiguration(): void
     {
         $builder = $this->getContainerBuilder();
 
@@ -100,7 +101,7 @@ class MessengerExtension extends CompilerExtension
      * @throws InvalidHandlerService
      * @throws MultipleHandlersFound
      */
-    public function beforeCompile() : void
+    public function beforeCompile(): void
     {
         $config  = $this->getConfig();
         $builder = $this->getContainerBuilder();
@@ -144,7 +145,7 @@ class MessengerExtension extends CompilerExtension
         $this->passRegisteredTransportFactoriesToMainFactory();
     }
 
-    public function afterCompile(ClassType $class) : void
+    public function afterCompile(ClassType $class): void
     {
         if (! $this->isPanelEnabled()) {
             return;
@@ -153,7 +154,7 @@ class MessengerExtension extends CompilerExtension
         $this->enableTracyIntegration($class);
     }
 
-    private function processBuses() : void
+    private function processBuses(): void
     {
         $builder = $this->getContainerBuilder();
 
@@ -190,7 +191,7 @@ class MessengerExtension extends CompilerExtension
     /**
      * @return Statement[]
      */
-    private function getSubscribers() : array
+    private function getSubscribers(): array
     {
         return [
             new Statement(DispatchPcntlSignalListener::class),
@@ -207,7 +208,7 @@ class MessengerExtension extends CompilerExtension
         ];
     }
 
-    private function processConsoleCommands() : void
+    private function processConsoleCommands(): void
     {
         $builder = $this->getContainerBuilder();
 
@@ -234,7 +235,7 @@ class MessengerExtension extends CompilerExtension
             ->setFactory(ConsumeMessagesCommand::class, [$routableBus, $receiverLocator, $eventDispatcher]);
     }
 
-    private function processTransports() : void
+    private function processTransports(): void
     {
         $builder = $this->getContainerBuilder();
 
@@ -282,14 +283,14 @@ class MessengerExtension extends CompilerExtension
         }
     }
 
-    private function processRouting() : void
+    private function processRouting(): void
     {
         $this->getContainerBuilder()->addDefinition($this->prefix('sendersLocator'))
             ->setFactory(
                 SendersLocator::class,
                 [
                     array_map(
-                        static function ($oneOrManyTransports) : array {
+                        static function ($oneOrManyTransports): array {
                                 return is_string($oneOrManyTransports) ? [$oneOrManyTransports] : $oneOrManyTransports;
                         },
                         $this->getConfig()->routing
@@ -301,7 +302,7 @@ class MessengerExtension extends CompilerExtension
     /**
      * @return string[] Service names
      */
-    private function getHandlersForBus(string $busName) : array
+    private function getHandlersForBus(string $busName): array
     {
         $builder = $this->getContainerBuilder();
 
@@ -315,7 +316,7 @@ class MessengerExtension extends CompilerExtension
 
         return array_filter(
             $serviceNames,
-            static function (string $serviceName) use ($builder, $busName) : bool {
+            static function (string $serviceName) use ($builder, $busName): bool {
                 $definition = $builder->getDefinition($serviceName);
 
                 return ($definition->getTag(self::TAG_HANDLER)['bus'] ?? $busName) === $busName;
@@ -328,7 +329,7 @@ class MessengerExtension extends CompilerExtension
      *
      * @throws InvalidHandlerService
      */
-    private function getHandledMessageNames(string $serviceName) : iterable
+    private function getHandledMessageNames(string $serviceName): iterable
     {
         $handlerClassName = $this->getContainerBuilder()->getDefinition($serviceName)->getType();
         assert(is_string($handlerClassName));
@@ -365,7 +366,7 @@ class MessengerExtension extends CompilerExtension
         return [$type->getName()];
     }
 
-    private function enableTracyIntegration(ClassType $class) : void
+    private function enableTracyIntegration(ClassType $class): void
     {
         $class->getMethod('initialize')->addBody($this->getContainerBuilder()->formatPhp('?;', [
             new Statement(
@@ -375,12 +376,12 @@ class MessengerExtension extends CompilerExtension
         ]));
     }
 
-    private function isPanelEnabled() : bool
+    private function isPanelEnabled(): bool
     {
         return $this->getContainerBuilder()->findByType(LogToPanelMiddleware::class) !== [];
     }
 
-    private function passRegisteredTransportFactoriesToMainFactory() : void
+    private function passRegisteredTransportFactoriesToMainFactory(): void
     {
         $builder = $this->getContainerBuilder();
 

--- a/src/Messenger/DI/TransportConfig.php
+++ b/src/Messenger/DI/TransportConfig.php
@@ -13,14 +13,10 @@ use Nette\DI\Definitions\Statement;
  */
 final class TransportConfig
 {
-    /** @var string */
-    public $dsn;
+    public string $dsn;
 
-    /**
-     * @var array
-     * @phpstan-var mixed[]
-     */
-    public $options = [];
+    /** @var array<string, mixed> */
+    public array $options = [];
 
     /**
      * Service/class used as serializer for given transport. When null is passed, default serializer will be used.

--- a/src/Messenger/Exceptions/InvalidHandlerService.php
+++ b/src/Messenger/Exceptions/InvalidHandlerService.php
@@ -7,11 +7,12 @@ namespace Fmasa\Messenger\Exceptions;
 use Exception;
 use ReflectionNamedType;
 use ReflectionType;
+
 use function sprintf;
 
 final class InvalidHandlerService extends Exception
 {
-    public static function missingInvokeMethod(string $serviceName, string $className) : self
+    public static function missingInvokeMethod(string $serviceName, string $className): self
     {
         return new self(sprintf(
             'Invalid handler service "%s": class "%s" must have an "__invoke()" method.',
@@ -20,7 +21,7 @@ final class InvalidHandlerService extends Exception
         ));
     }
 
-    public static function missingArgumentType(string $serviceName, string $className, string $parameterName) : self
+    public static function missingArgumentType(string $serviceName, string $className, string $parameterName): self
     {
         return new self(sprintf(
             'Invalid handler service "%s": argument "$%s" of method "%s::__invoke()"'
@@ -31,7 +32,7 @@ final class InvalidHandlerService extends Exception
         ));
     }
 
-    public static function wrongAmountOfArguments(string $serviceName, string $className) : self
+    public static function wrongAmountOfArguments(string $serviceName, string $className): self
     {
         return new self(sprintf(
             'Invalid handler service "%s": method "%s::__invoke()" requires exactly one argument,'
@@ -46,7 +47,7 @@ final class InvalidHandlerService extends Exception
         string $className,
         string $parameterName,
         ReflectionType $type
-    ) : self {
+    ): self {
         return new self(sprintf(
             'Invalid handler service "%s": type-hint of argument "$%s"'
             . ' in method "%s::__invoke()" must be a class , "%s" given.',

--- a/src/Messenger/Exceptions/MultipleHandlersFound.php
+++ b/src/Messenger/Exceptions/MultipleHandlersFound.php
@@ -6,6 +6,7 @@ namespace Fmasa\Messenger\Exceptions;
 
 use Exception;
 use Nette\DI\Definitions\Definition;
+
 use function array_map;
 use function implode;
 use function sprintf;
@@ -15,7 +16,7 @@ final class MultipleHandlersFound extends Exception
     /**
      * @param Definition[] $handlers
      */
-    public static function fromHandlerClasses(string $messageName, array $handlers) : self
+    public static function fromHandlerClasses(string $messageName, array $handlers): self
     {
         return new self(sprintf(
             'There are multiple handlers for message "%s": %s',
@@ -23,7 +24,7 @@ final class MultipleHandlersFound extends Exception
             implode(
                 ', ',
                 array_map(
-                    static function (Definition $definition) : string {
+                    static function (Definition $definition): string {
                         return sprintf('%s (%s)', $definition->getName(), $definition->getType());
                     },
                     $handlers

--- a/src/Messenger/Exceptions/SenderNotFound.php
+++ b/src/Messenger/Exceptions/SenderNotFound.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Fmasa\Messenger\Exceptions;
 
 use RuntimeException;
+
 use function sprintf;
 
 class SenderNotFound extends RuntimeException
 {
-    public static function withAlias(string $alias) : self
+    public static function withAlias(string $alias): self
     {
         return new self(sprintf(
             'Sender with alias "%s" was not found',

--- a/src/Messenger/Exceptions/ServiceNotFound.php
+++ b/src/Messenger/Exceptions/ServiceNotFound.php
@@ -6,11 +6,12 @@ namespace Fmasa\Messenger\Exceptions;
 
 use Exception;
 use Psr\Container\NotFoundExceptionInterface;
+
 use function sprintf;
 
 final class ServiceNotFound extends Exception implements NotFoundExceptionInterface
 {
-    public static function withTag(string $tagName, string $tagValue) : self
+    public static function withTag(string $tagName, string $tagValue): self
     {
         return new self(sprintf('Service with tag "%s" = "%s" was not found', $tagName, $tagValue));
     }

--- a/src/Messenger/LazyHandlersLocator.php
+++ b/src/Messenger/LazyHandlersLocator.php
@@ -8,6 +8,7 @@ use Nette\DI\Container;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+
 use function assert;
 use function get_class;
 use function is_callable;
@@ -18,10 +19,9 @@ use function is_callable;
 final class LazyHandlersLocator implements HandlersLocatorInterface
 {
     /** @var array<string, array<string, string|null>> message type => [handler service name => alias] */
-    private $handlersMap;
+    private array $handlersMap;
 
-    /** @var Container */
-    private $container;
+    private Container $container;
 
     /**
      * @param array<string, array<string, string|null>> $handlersMap
@@ -35,7 +35,7 @@ final class LazyHandlersLocator implements HandlersLocatorInterface
     /**
      * @return HandlerDescriptor[]
      */
-    public function getHandlers(Envelope $envelope) : iterable
+    public function getHandlers(Envelope $envelope): iterable
     {
         $handlers = [];
 

--- a/src/Messenger/MessageTypeResolver.php
+++ b/src/Messenger/MessageTypeResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fmasa\Messenger;
 
 use Symfony\Component\Messenger\Envelope;
+
 use function class_implements;
 use function class_parents;
 use function get_class;
@@ -17,7 +18,7 @@ final class MessageTypeResolver
     /**
      * @return string[]
      */
-    public static function listTypes(Envelope $envelope) : array
+    public static function listTypes(Envelope $envelope): array
     {
         $class = get_class($envelope->getMessage());
 

--- a/src/Messenger/Tracy/HandledMessage.php
+++ b/src/Messenger/Tracy/HandledMessage.php
@@ -6,17 +6,13 @@ namespace Fmasa\Messenger\Tracy;
 
 final class HandledMessage
 {
-    /** @var string */
-    private $messageName;
+    private string $messageName;
 
-    /** @var float */
-    private $timeInMs;
+    private float $timeInMs;
 
-    /** @var string */
-    private $messageDump;
+    private string $messageDump;
 
-    /** @var string */
-    private $resultDump;
+    private string $resultDump;
 
     public function __construct(string $messageName, float $timeInMs, string $messageDump, string $resultDump)
     {
@@ -26,22 +22,22 @@ final class HandledMessage
         $this->resultDump  = $resultDump;
     }
 
-    public function getMessageName() : string
+    public function getMessageName(): string
     {
         return $this->messageName;
     }
 
-    public function getTimeInMs() : float
+    public function getTimeInMs(): float
     {
         return $this->timeInMs;
     }
 
-    public function getMessageDump() : string
+    public function getMessageDump(): string
     {
         return $this->messageDump;
     }
 
-    public function getResultDump() : string
+    public function getResultDump(): string
     {
         return $this->resultDump;
     }

--- a/src/Messenger/Tracy/LogToPanelMiddleware.php
+++ b/src/Messenger/Tracy/LogToPanelMiddleware.php
@@ -9,6 +9,7 @@ use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Tracy\Debugger;
+
 use function array_map;
 use function count;
 use function explode;
@@ -19,18 +20,17 @@ use function round;
 
 final class LogToPanelMiddleware implements MiddlewareInterface
 {
-    /** @var string */
-    private $busName;
+    private string $busName;
 
     /** @var HandledMessage[] */
-    private $handledMessages = [];
+    private array $handledMessages = [];
 
     public function __construct(string $busName)
     {
         $this->busName = $busName;
     }
 
-    public function handle(Envelope $envelope, StackInterface $stack) : Envelope
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $time = microtime(true);
 
@@ -45,7 +45,7 @@ final class LogToPanelMiddleware implements MiddlewareInterface
             implode(
                 "\n",
                 array_map(
-                    static function (HandledStamp $stamp) : string {
+                    static function (HandledStamp $stamp): string {
                         return Debugger::dump($stamp->getResult(), true);
                     },
                     $result->all(HandledStamp::class)
@@ -56,7 +56,7 @@ final class LogToPanelMiddleware implements MiddlewareInterface
         return $result;
     }
 
-    public function getBusName() : string
+    public function getBusName(): string
     {
         return $this->busName;
     }
@@ -64,12 +64,12 @@ final class LogToPanelMiddleware implements MiddlewareInterface
     /**
      * @return HandledMessage[]
      */
-    public function getHandledMessages() : array
+    public function getHandledMessages(): array
     {
         return $this->handledMessages;
     }
 
-    private function getMessageName(Envelope $envelope) : string
+    private function getMessageName(Envelope $envelope): string
     {
         $nameParts = explode('\\', get_class($envelope->getMessage()));
 

--- a/src/Messenger/Tracy/MessengerPanel.php
+++ b/src/Messenger/Tracy/MessengerPanel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fmasa\Messenger\Tracy;
 
 use Tracy\IBarPanel;
+
 use function array_filter;
 use function array_map;
 use function count;
@@ -16,7 +17,7 @@ use function ob_start;
 final class MessengerPanel implements IBarPanel
 {
     /** @var LogToPanelMiddleware[] */
-    private $middlewares;
+    private array $middlewares;
 
     /**
      * @param LogToPanelMiddleware[] $middlewares
@@ -26,13 +27,13 @@ final class MessengerPanel implements IBarPanel
         $this->middlewares = $middlewares;
     }
 
-    public function getTab() : string
+    public function getTab(): string
     {
         $counter = implode(
             '+',
             array_filter(
                 array_map(
-                    static function (LogToPanelMiddleware $middleware) : int {
+                    static function (LogToPanelMiddleware $middleware): int {
                         return count($middleware->getHandledMessages());
                     },
                     $this->middlewares
@@ -43,10 +44,10 @@ final class MessengerPanel implements IBarPanel
         return file_get_contents(__DIR__ . '/icon.svg') . $counter . ' messages ';
     }
 
-    public function getPanel() : string
+    public function getPanel(): string
     {
         $buses = array_map(
-            function (LogToPanelMiddleware $middleware) : string {
+            function (LogToPanelMiddleware $middleware): string {
                 return $this->renderBus($middleware);
             },
             $this->middlewares
@@ -59,7 +60,7 @@ final class MessengerPanel implements IBarPanel
         return (string) ob_get_clean();
     }
 
-    private function renderBus(LogToPanelMiddleware $middleware) : string
+    private function renderBus(LogToPanelMiddleware $middleware): string
     {
         $busName         = $middleware->getBusName();
         $handledMessages = $middleware->getHandledMessages();
@@ -72,7 +73,7 @@ final class MessengerPanel implements IBarPanel
         return (string) ob_get_clean();
     }
 
-    private function getIcon() : string
+    private function getIcon(): string
     {
         return (string) file_get_contents(__DIR__ . '/icon.svg');
     }

--- a/src/Messenger/Transport/SendersLocator.php
+++ b/src/Messenger/Transport/SendersLocator.php
@@ -10,6 +10,7 @@ use Nette\DI\Container;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
+
 use function assert;
 
 final class SendersLocator implements SendersLocatorInterface
@@ -17,10 +18,9 @@ final class SendersLocator implements SendersLocatorInterface
     public const TAG_SENDER_ALIAS = 'messenger.sender.alias';
 
     /** @var array<string, string[]> */
-    private $messageTypeToSender;
+    private array $messageTypeToSender;
 
-    /** @var Container */
-    private $container;
+    private Container $container;
 
     /**
      * @param array<string, string[]> $messageTypeToSenders
@@ -34,7 +34,7 @@ final class SendersLocator implements SendersLocatorInterface
     /**
      * @inheritDoc
      */
-    public function getSenders(Envelope $envelope) : iterable
+    public function getSenders(Envelope $envelope): iterable
     {
         foreach (MessageTypeResolver::listTypes($envelope) as $type) {
             foreach ($this->messageTypeToSender[$type] ?? [] as $alias) {
@@ -43,10 +43,7 @@ final class SendersLocator implements SendersLocatorInterface
         }
     }
 
-    /**
-     * @inheritDoc
-     */
-    private function getSenderByAlias(string $alias) : SenderInterface
+    private function getSenderByAlias(string $alias): SenderInterface
     {
         foreach ($this->container->findByTag(self::TAG_SENDER_ALIAS) as $serviceName => $serviceAlias) {
             if ($serviceAlias !== $alias) {

--- a/src/Messenger/Transport/TaggedServiceLocator.php
+++ b/src/Messenger/Transport/TaggedServiceLocator.php
@@ -9,18 +9,15 @@ use Nette\DI\Container;
 use Psr\Container\ContainerInterface;
 
 // ContainerInterface does not use typehints, so we cannot add them without breaking LSP
-// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration
+// phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint
 
 final class TaggedServiceLocator implements ContainerInterface
 {
-    /** @var string */
-    private $tagName;
+    private string $tagName;
 
-    /** @var Container */
-    private $container;
+    private Container $container;
 
-    /** @var string|null */
-    private $defaultServiceName;
+    private ?string $defaultServiceName = null;
 
     public function __construct(string $tagName, Container $container, ?string $defaultServiceName = null)
     {
@@ -30,11 +27,9 @@ final class TaggedServiceLocator implements ContainerInterface
     }
 
     /**
-     * @param string $id
-     *
-     * @return object
+     * @var string $id
      */
-    public function get($id)
+    public function get($id): object
     {
         foreach ($this->container->findByTag($this->tagName) as $serviceName => $receiverName) {
             if ($receiverName === $id) {
@@ -50,9 +45,9 @@ final class TaggedServiceLocator implements ContainerInterface
     }
 
     /**
-     * @param string $id
+     * @var string $id
      */
-    public function has($id) : bool
+    public function has($id): bool
     {
         foreach ($this->container->findByTag($this->tagName) as $receiverName) {
             if ($receiverName === $id) {

--- a/tests/DI/MessengerExtensionTest.php
+++ b/tests/DI/MessengerExtensionTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
+
 use function array_map;
 use function assert;
 use function mkdir;
@@ -32,7 +33,7 @@ use function uniqid;
 
 final class MessengerExtensionTest extends TestCase
 {
-    public function testAddingMiddleware() : void
+    public function testAddingMiddleware(): void
     {
         $container = $this->getContainer(__DIR__ . '/middlewares.neon');
 
@@ -48,7 +49,7 @@ final class MessengerExtensionTest extends TestCase
         $this->assertSame('second', $stamps[1]->getValue());
     }
 
-    public function testExceptionIsThrownIfThereAreMultipleHandlersWhenSingleHandlerPerMessageIsTrue() : void
+    public function testExceptionIsThrownIfThereAreMultipleHandlersWhenSingleHandlerPerMessageIsTrue(): void
     {
         $this->expectException(MultipleHandlersFound::class);
 
@@ -60,7 +61,7 @@ final class MessengerExtensionTest extends TestCase
      *
      * @dataProvider dataMultipleHandlers
      */
-    public function testMultipleHandlersAreCalled(string $configFiles, array $expectedResults) : void
+    public function testMultipleHandlersAreCalled(string $configFiles, array $expectedResults): void
     {
         $container = $this->getContainer($configFiles);
 
@@ -76,7 +77,7 @@ final class MessengerExtensionTest extends TestCase
     /**
      * @return (string|string[])[][]
      */
-    public static function dataMultipleHandlers() : array
+    public static function dataMultipleHandlers(): array
     {
         return [
             [__DIR__ . '/multipleHandlers.neon', ['first result', 'second result', 'fixed result']],
@@ -85,7 +86,7 @@ final class MessengerExtensionTest extends TestCase
         ];
     }
 
-    public function testHandlersRestrictedToCertainBus() : void
+    public function testHandlersRestrictedToCertainBus(): void
     {
         $container = $this->getContainer(__DIR__ . '/restrictedHandlers.neon');
 
@@ -100,7 +101,7 @@ final class MessengerExtensionTest extends TestCase
     /**
      * @dataProvider dataInvalidHandlerConfigs
      */
-    public function testInvalidHandlersThrowException(string $configFile) : void
+    public function testInvalidHandlersThrowException(string $configFile): void
     {
         $this->expectException(InvalidHandlerService::class);
 
@@ -110,7 +111,7 @@ final class MessengerExtensionTest extends TestCase
     /**
      * @return string[][]
      */
-    public function dataInvalidHandlerConfigs() : array
+    public function dataInvalidHandlerConfigs(): array
     {
         return [
             [__DIR__ . '/invalidHandler.invalidArgumentType.neon'],
@@ -121,7 +122,7 @@ final class MessengerExtensionTest extends TestCase
         ];
     }
 
-    public function testTracyPanel() : void
+    public function testTracyPanel(): void
     {
         $container = $this->getContainer(__DIR__ . '/twoBusesWithTracy.neon');
 
@@ -140,7 +141,7 @@ final class MessengerExtensionTest extends TestCase
         $this->assertRegExp('~Handled messages~', $panel->getPanel());
     }
 
-    public function testLogToPanelMiddlewareIsNotRegisteredIfPanelIsDisabled() : void
+    public function testLogToPanelMiddlewareIsNotRegisteredIfPanelIsDisabled(): void
     {
         $container = $this->getContainer(__DIR__ . '/withoutPanel.neon');
 
@@ -153,7 +154,7 @@ final class MessengerExtensionTest extends TestCase
      *
      * @dataProvider dataMessagedRoutedToMemoryTransport
      */
-    public function testMessageIsPassedToTransport($message, array $transports) : void
+    public function testMessageIsPassedToTransport($message, array $transports): void
     {
         $container = $this->getContainer(__DIR__ . '/transports.neon');
 
@@ -163,7 +164,7 @@ final class MessengerExtensionTest extends TestCase
         $this->assertSame(
             $transports,
             array_map(
-                static function (SentStamp $stamp) : string {
+                static function (SentStamp $stamp): string {
                     return $stamp->getSenderAlias();
                 },
                 $bus->dispatch($message)->all(SentStamp::class)
@@ -174,20 +175,20 @@ final class MessengerExtensionTest extends TestCase
     /**
      * @return mixed[]
      */
-    public static function dataMessagedRoutedToMemoryTransport() : array
+    public static function dataMessagedRoutedToMemoryTransport(): array
     {
         return [
             'message routed to one transport' => [new Message(), ['memory1']],
             'message routed to one transport (set as array)' => [new Message2(), ['memory1']],
             'message routed to two transports' => [new Message3(), ['memory1', 'memory2']],
-            'message routed to two transports (to first via interface, to second via class name)'=> [
+            'message routed to two transports (to first via interface, to second via class name)' => [
                 new MessageImplementingInterface(),
                 ['memory2', 'memory1'],
             ],
         ];
     }
 
-    public function testRegisterCustomTransport() : void
+    public function testRegisterCustomTransport(): void
     {
         $container = $this->getContainer(__DIR__ . '/customTransport.neon');
 
@@ -204,7 +205,7 @@ final class MessengerExtensionTest extends TestCase
         $this->assertSame([$message], $container->getByType(CustomTransport::class)->getSentMessages());
     }
 
-    public function testDnsAndOptionsAndCustomDefaultSerializerArePassedToSender() : void
+    public function testDnsAndOptionsAndCustomDefaultSerializerArePassedToSender(): void
     {
         $container = $this->getContainer(__DIR__ . '/optionsPassed.neon');
 
@@ -220,7 +221,7 @@ final class MessengerExtensionTest extends TestCase
         $this->assertInstanceOf(DummySerializer::class, $transportFactory->getUsedSerializer());
     }
 
-    public function testCustomSerializerIsPassedToSender() : void
+    public function testCustomSerializerIsPassedToSender(): void
     {
         $container = $this->getContainer(__DIR__ . '/customSerializer.neon');
 
@@ -234,7 +235,7 @@ final class MessengerExtensionTest extends TestCase
         );
     }
 
-    public function testBusLocatorReturnsCorrectBuses() : void
+    public function testBusLocatorReturnsCorrectBuses(): void
     {
         $container = $this->getContainer(__DIR__ . '/busLocator.neon');
 
@@ -249,14 +250,14 @@ final class MessengerExtensionTest extends TestCase
     /**
      * @param string[] $expectedResults
      */
-    private function assertResultsAreSame(array $expectedResults, Envelope $envelope) : void
+    private function assertResultsAreSame(array $expectedResults, Envelope $envelope): void
     {
         $stamps = $envelope->all(HandledStamp::class);
 
         $this->assertSame(
             $expectedResults,
             array_map(
-                static function (HandledStamp $stamp) : string {
+                static function (HandledStamp $stamp): string {
                     return $stamp->getResult();
                 },
                 $stamps
@@ -264,7 +265,7 @@ final class MessengerExtensionTest extends TestCase
         );
     }
 
-    private function getContainer(string $configFile) : Container
+    private function getContainer(string $configFile): Container
     {
         $tempDir = sys_get_temp_dir() . '/' . uniqid('MessengerExtensionTest', true);
         mkdir($tempDir);

--- a/tests/fixtures/CustomTransport.php
+++ b/tests/fixtures/CustomTransport.php
@@ -10,25 +10,25 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 final class CustomTransport implements TransportInterface
 {
     /** @var object[] */
-    private $sentMessages = [];
+    private array $sentMessages = [];
 
     /**
      * @return Envelope[]
      */
-    public function get() : iterable
+    public function get(): iterable
     {
         return [];
     }
 
-    public function ack(Envelope $envelope) : void
+    public function ack(Envelope $envelope): void
     {
     }
 
-    public function reject(Envelope $envelope) : void
+    public function reject(Envelope $envelope): void
     {
     }
 
-    public function send(Envelope $envelope) : Envelope
+    public function send(Envelope $envelope): Envelope
     {
         $this->sentMessages[] = $envelope->getMessage();
 
@@ -38,7 +38,7 @@ final class CustomTransport implements TransportInterface
     /**
      * @return Envelope[]
      */
-    public function getSentMessages() : array
+    public function getSentMessages(): array
     {
         return $this->sentMessages;
     }

--- a/tests/fixtures/CustomTransportFactory.php
+++ b/tests/fixtures/CustomTransportFactory.php
@@ -7,21 +7,19 @@ namespace Fixtures;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
+
 use function strpos;
 
 final class CustomTransportFactory implements TransportFactoryInterface
 {
-    /** @var CustomTransport */
-    private $transport;
+    private CustomTransport $transport;
 
-    /** @var string|null */
-    private $dns;
+    private ?string $dns = null;
 
     /** @var mixed[]|null */
-    private $options;
+    private ?array $options = null;
 
-    /** @var SerializerInterface|null */
-    private $serializer;
+    private ?SerializerInterface $serializer = null;
 
     public function __construct(CustomTransport $transport)
     {
@@ -31,7 +29,7 @@ final class CustomTransportFactory implements TransportFactoryInterface
     /**
      * @param mixed[] $options
      */
-    public function createTransport(string $dsn, array $options, SerializerInterface $serializer) : TransportInterface
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
         $this->dns        = $dsn;
         $this->options    = $options;
@@ -40,7 +38,7 @@ final class CustomTransportFactory implements TransportFactoryInterface
         return $this->transport;
     }
 
-    public function getUsedDns() : ?string
+    public function getUsedDns(): ?string
     {
         return $this->dns;
     }
@@ -48,12 +46,12 @@ final class CustomTransportFactory implements TransportFactoryInterface
     /**
      * @return mixed[]
      */
-    public function getUsedOptions() : ?array
+    public function getUsedOptions(): ?array
     {
         return $this->options;
     }
 
-    public function getUsedSerializer() : ?SerializerInterface
+    public function getUsedSerializer(): ?SerializerInterface
     {
         return $this->serializer;
     }
@@ -61,7 +59,7 @@ final class CustomTransportFactory implements TransportFactoryInterface
     /**
      * @param mixed[] $options
      */
-    public function supports(string $dsn, array $options) : bool
+    public function supports(string $dsn, array $options): bool
     {
         return strpos($dsn, 'custom://') === 0;
     }

--- a/tests/fixtures/DummySerializer.php
+++ b/tests/fixtures/DummySerializer.php
@@ -13,7 +13,7 @@ final class DummySerializer implements SerializerInterface
     /**
      * @param mixed[] $encodedEnvelope
      */
-    public function decode(array $encodedEnvelope) : Envelope
+    public function decode(array $encodedEnvelope): Envelope
     {
         return new Envelope(new stdClass());
     }
@@ -21,7 +21,7 @@ final class DummySerializer implements SerializerInterface
     /**
      * @return array<string, string>
      */
-    public function encode(Envelope $envelope) : array
+    public function encode(Envelope $envelope): array
     {
         return [
             'headers' => '',

--- a/tests/fixtures/FixedHandler.php
+++ b/tests/fixtures/FixedHandler.php
@@ -6,7 +6,7 @@ namespace Fixtures;
 
 final class FixedHandler
 {
-    public function __invoke(Message $message, bool $optionalArgument = true) : string
+    public function __invoke(Message $message, bool $optionalArgument = true): string
     {
         return 'fixed result';
     }

--- a/tests/fixtures/Handler.php
+++ b/tests/fixtures/Handler.php
@@ -6,25 +6,23 @@ namespace Fixtures;
 
 class Handler
 {
-    /** @var bool */
-    private $called = false;
+    private bool $called = false;
 
-    /** @var string|null */
-    private $result;
+    private ?string $result = null;
 
     public function __construct(?string $result = null)
     {
         $this->result = $result;
     }
 
-    public function __invoke(Message $message) : ?string
+    public function __invoke(Message $message): ?string
     {
         $this->called = true;
 
         return $this->result;
     }
 
-    public function isCalled() : bool
+    public function isCalled(): bool
     {
         return $this->called;
     }

--- a/tests/fixtures/HandlerWithInvalidArgumentType.php
+++ b/tests/fixtures/HandlerWithInvalidArgumentType.php
@@ -6,7 +6,7 @@ namespace Fixtures;
 
 final class HandlerWithInvalidArgumentType
 {
-    public function __invoke(int $message) : void
+    public function __invoke(int $message): void
     {
     }
 }

--- a/tests/fixtures/HandlerWithTooManyArguments.php
+++ b/tests/fixtures/HandlerWithTooManyArguments.php
@@ -6,7 +6,7 @@ namespace Fixtures;
 
 final class HandlerWithTooManyArguments
 {
-    public function __invoke(Message $first, Message $second) : void
+    public function __invoke(Message $first, Message $second): void
     {
     }
 }

--- a/tests/fixtures/HandlerWithoutArgumentType.php
+++ b/tests/fixtures/HandlerWithoutArgumentType.php
@@ -9,7 +9,7 @@ final class HandlerWithoutArgumentType
     /**
      * @param mixed $message
      */
-    public function __invoke($message) : void
+    public function __invoke($message): void
     {
     }
 }

--- a/tests/fixtures/HandlerWithoutArguments.php
+++ b/tests/fixtures/HandlerWithoutArguments.php
@@ -6,7 +6,7 @@ namespace Fixtures;
 
 final class HandlerWithoutArguments
 {
-    public function __invoke() : void
+    public function __invoke(): void
     {
     }
 }

--- a/tests/fixtures/Stamp.php
+++ b/tests/fixtures/Stamp.php
@@ -8,15 +8,14 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 
 final class Stamp implements StampInterface
 {
-    /** @var string */
-    private $value;
+    private string $value;
 
     public function __construct(string $value)
     {
         $this->value = $value;
     }
 
-    public function getValue() : string
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/tests/fixtures/StampAddingMiddleware.php
+++ b/tests/fixtures/StampAddingMiddleware.php
@@ -11,15 +11,14 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 
 final class StampAddingMiddleware implements MiddlewareInterface
 {
-    /** @var StampInterface */
-    private $stamp;
+    private StampInterface $stamp;
 
     public function __construct(StampInterface $stamp)
     {
         $this->stamp = $stamp;
     }
 
-    public function handle(Envelope $envelope, StackInterface $stack) : Envelope
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         return $stack->next()->handle($envelope->with($this->stamp), $stack);
     }


### PR DESCRIPTION
I decided to drop support for PHP 7.3 as well, because:
- I don't personally use it anywhere
- It makes fiddling with PHPUnit harder (as it keeps supported PHP version range narrow)

I will always try to support at least one overlapping versions, so automatic updates of this library are possible.
