### PR TITLE
Support for specifying handler method inside getHandledMessages

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,8 @@
 parameters:
     ignoreErrors:
-        - "~Parameter #1 \\$objectOrClass of class ReflectionClass constructor expects class-string<T of object>\\|T of object, string given.~"
-        - "~Parameter #1 \\$callback of function call_user_func expects callable\\(\\): mixed, array\\(string, 'getHandledMessages'\\) given\\.~"
-        - '~Cannot access property (\$buses|\$transports|\$routing|\$serializer|\$failureTransport) on array\|object.~'
-        - '~Cannot access property \$failureTransport on Fmasa\\Messenger\\DI\\TransportConfig\|string.~'
+        - '~Cannot access property (\$buses|\$transports|\$routing|\$serializer|\$failureTransport) on array\|object\.~'
+        - '~Cannot access property \$failureTransport on Fmasa\\Messenger\\DI\\TransportConfig\|string\.~'
+        - '~Unable to resolve the template type T in call to method Nette\\DI\\ContainerBuilder::addDefinition\(~'
+        - '~Call to an undefined method Nette\\DI\\Definitions\\Definition::setArguments\(~'
+        - '~Call to an undefined method Nette\\DI\\Definitions\\Definition::setFactory\(~'
+        - '~Call to protected method setType\(\) of class Nette\\DI\\Definitions\\Definition\.~'

--- a/src/Messenger/DI/HandlerDefinition.php
+++ b/src/Messenger/DI/HandlerDefinition.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fmasa\Messenger\DI;
+
+/**
+ * @internal
+ */
+final class HandlerDefinition
+{
+    public string $serviceName;
+
+    public string $methodName;
+
+    public ?string $alias;
+
+    public function __construct(string $serviceName, string $methodName, ?string $alias = null)
+    {
+        $this->serviceName = $serviceName;
+        $this->methodName  = $methodName;
+        $this->alias       = $alias;
+    }
+}

--- a/tests/DI/MessengerExtensionTest.php
+++ b/tests/DI/MessengerExtensionTest.php
@@ -79,6 +79,24 @@ final class MessengerExtensionTest extends TestCase
         );
     }
 
+    public function testSingleHandlerHandlesMultipleMessages(): void
+    {
+        $container = $this->getContainer(__DIR__ . '/messageSubscribers.neon');
+
+        $messageBus = $container->getService('messenger.default.bus');
+        assert($messageBus instanceof MessageBusInterface);
+
+        $this->assertResultsAreSame(
+            ['message result', 'result from callable'],
+            $messageBus->dispatch(new Message())
+        );
+
+        $this->assertResultsAreSame(
+            ['message2 result'],
+            $messageBus->dispatch(new Message2())
+        );
+    }
+
     /**
      * @return (string|string[])[][]
      */

--- a/tests/DI/messageSubscribers.neon
+++ b/tests/DI/messageSubscribers.neon
@@ -1,0 +1,7 @@
+messenger:
+    buses:
+        default:
+
+services:
+    - Fixtures\MessageSubscriber
+    - Fixtures\CallableMessageSubscriber

--- a/tests/fixtures/CallableMessageSubscriber.php
+++ b/tests/fixtures/CallableMessageSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+
+final class CallableMessageSubscriber implements MessageSubscriberInterface
+{
+    /**
+     * @return iterable<string, array{method: string}>
+     */
+    public static function getHandledMessages(): iterable
+    {
+        yield Message::class;
+    }
+
+    public function __invoke(Message $message): string
+    {
+        return 'result from callable';
+    }
+}

--- a/tests/fixtures/MessageSubscriber.php
+++ b/tests/fixtures/MessageSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+
+final class MessageSubscriber implements MessageSubscriberInterface
+{
+    /**
+     * @return iterable<string, array{method: string}>
+     */
+    public static function getHandledMessages(): iterable
+    {
+        yield Message::class => ['method' => 'handleMessage'];
+        yield Message2::class => ['method' => 'handleMessage2'];
+    }
+
+    public function handleMessage(Message $message): string
+    {
+        return 'message result';
+    }
+
+    public function handleMessage2(Message2 $message2): string
+    {
+        return 'message2 result';
+    }
+}


### PR DESCRIPTION
Symfony `getHandledMessages` supports specifying a method for each handled message.
https://symfony.com/doc/current/messenger.html#handler-subscriber-options

`__invoke` is the default and is mostly good enough for command buses (one command has one handler). But for event buses it is quite common to have one subscriber listening to multiple events.

OFC method is not the only option and supporting the others would be nice but it was good enough for me.
