### PR TITLE
Ability to autowire EventDispatcher

### DIFF
--- a/tests/DI/autowiredEventDispatcher.neon
+++ b/tests/DI/autowiredEventDispatcher.neon
@@ -1,0 +1,8 @@
+messenger:
+    buses:
+        default:
+    transports:
+        test: in-memory://
+
+services:
+    eventDispatcher: Symfony\Component\EventDispatcher\EventDispatcher

--- a/tests/DI/defaultEventDispatcher.neon
+++ b/tests/DI/defaultEventDispatcher.neon
@@ -1,0 +1,5 @@
+messenger:
+    buses:
+        default:
+    transports:
+        test: in-memory://


### PR DESCRIPTION
Hello. I'd like to listen to events dispatched by `Symfony\Component\Messenger\Worker` (from `Symfony\Component\Messenger\Event` namespace).
In Symfony, there is (mostly) only one EventDispatcher instance which is shared thru the application and an extension allowing usage of special tags like `kernel.event_listener` or `kernel.event_subscriber` so it is easy to register a listener (or subscriber).

There are some packages for EventDispatcher integration into Nette like https://contributte.org/packages/contributte/event-dispatcher.html#content
but since this package registers its own EventDispatcher instance 
https://github.com/fmasa/messenger/blob/master/src/Messenger/DI/MessengerExtension.php#L237
then it is not possible to use it's features.

This PR tries to autowire an instance of EventDispatcher and if there is none, only then it creates it's own definition.
Different solution might be to pass a service name using configuration or to provide it's own tags (or both). Let me know if you like it or not or if you prefer a different solution. I guess you will be missing tests. I will write them later if you're interested.