### PR TITLE
Added support for handler tag options and subscriber options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"symfony/event-dispatcher": "^4.4|^5.0",
 		"symfony/messenger": "^5.3",
 		"symfony/console": "^4.4|^5.0",
-		"nette/di": "^3.0.1",
+		"nette/di": "^3.0.6",
 		"nette/schema": "^1.0.3",
 		"tracy/tracy": "^2.6"
 	},

--- a/src/Messenger/DI/HandlerDefinition.php
+++ b/src/Messenger/DI/HandlerDefinition.php
@@ -13,12 +13,16 @@ final class HandlerDefinition
 
     public string $methodName;
 
-    public ?string $alias;
+    /** @var array<string, mixed> */
+    public array $options;
 
-    public function __construct(string $serviceName, string $methodName, ?string $alias = null)
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $serviceName, string $methodName, array $options)
     {
         $this->serviceName = $serviceName;
         $this->methodName  = $methodName;
-        $this->alias       = $alias;
+        $this->options     = $options;
     }
 }

--- a/src/Messenger/DI/MessengerExtension.php
+++ b/src/Messenger/DI/MessengerExtension.php
@@ -392,15 +392,13 @@ class MessengerExtension extends CompilerExtension
         return $handlerDefinitionsByMessage;
     }
 
-	/**
-	 * @param ReflectionClass<object> $handlerReflection
-	 * @param string $serviceName
-	 * @param string $methodName
-	 *
-	 * @return iterable<string>
-	 *
-	 * @throws \Fmasa\Messenger\Exceptions\InvalidHandlerService
-	 */
+    /**
+     * @param ReflectionClass<object> $handlerReflection
+     *
+     * @return iterable<string>
+     *
+     * @throws InvalidHandlerService
+     */
     private function guessHandledClasses(ReflectionClass $handlerReflection, string $serviceName, string $methodName): iterable
     {
         $handlerClassName = $handlerReflection->getName();

--- a/src/Messenger/DI/MessengerExtension.php
+++ b/src/Messenger/DI/MessengerExtension.php
@@ -441,7 +441,7 @@ class MessengerExtension extends CompilerExtension
                 }
             }
 
-            if ($types) {
+            if (count($types) > 0) {
                 return $methodName === '__invoke' ? $types : array_fill_keys($types, $methodName);
             }
 

--- a/src/Messenger/Exceptions/InvalidHandlerService.php
+++ b/src/Messenger/Exceptions/InvalidHandlerService.php
@@ -8,53 +8,80 @@ use Exception;
 use ReflectionNamedType;
 use ReflectionType;
 
+use function implode;
 use function sprintf;
 
 final class InvalidHandlerService extends Exception
 {
-    public static function missingInvokeMethod(string $serviceName, string $className): self
+    public static function missingHandlerMethod(string $serviceName, string $className, string $methodName): self
     {
         return new self(sprintf(
-            'Invalid handler service "%s": class "%s" must have an "__invoke()" method.',
+            'Invalid handler service "%s": class "%s" must have an "%s()" method.',
             $serviceName,
-            $className
+            $className,
+            $methodName
         ));
     }
 
-    public static function missingArgumentType(string $serviceName, string $className, string $parameterName): self
+    public static function missingArgumentType(string $serviceName, string $className, string $methodName, string $parameterName): self
     {
         return new self(sprintf(
-            'Invalid handler service "%s": argument "$%s" of method "%s::__invoke()"'
+            'Invalid handler service "%s": argument "$%s" of method "%s::%s()"'
             . ' must have a type-hint corresponding to the message class it handles.',
             $serviceName,
             $parameterName,
-            $className
+            $className,
+            $methodName
         ));
     }
 
-    public static function wrongAmountOfArguments(string $serviceName, string $className): self
+    public static function wrongAmountOfArguments(string $serviceName, string $className, string $methodName): self
     {
         return new self(sprintf(
-            'Invalid handler service "%s": method "%s::__invoke()" requires exactly one argument,'
+            'Invalid handler service "%s": method "%s::%s()" requires exactly one argument,'
             . ' first one being the message it handles.',
             $serviceName,
-            $className
+            $className,
+            $methodName
         ));
     }
 
     public static function invalidArgumentType(
         string $serviceName,
         string $className,
+        string $methodName,
         string $parameterName,
         ReflectionType $type
     ): self {
         return new self(sprintf(
             'Invalid handler service "%s": type-hint of argument "$%s"'
-            . ' in method "%s::__invoke()" must be a class , "%s" given.',
+            . ' in method "%s::%s()" must be a class , "%s" given.',
             $serviceName,
             $parameterName,
             $className,
+            $methodName,
             $type instanceof ReflectionNamedType ? $type->getName() : (string) $type
+        ));
+    }
+
+    /**
+     * @param array<string> $types
+     */
+    public static function invalidArgumentUnionType(
+        string $serviceName,
+        string $className,
+        string $methodName,
+        string $parameterName,
+        array $types
+    ): self {
+        return new self(sprintf(
+            'Invalid handler service "%s": type-hint of argument "$%s"'
+            . ' in method "%s::%s()" must be a class , "%s" given.',
+            $serviceName,
+            $parameterName,
+            $className,
+            $methodName,
+            implode('|', $types)
         ));
     }
 }

--- a/tests/DI/MessengerExtensionTest.php
+++ b/tests/DI/MessengerExtensionTest.php
@@ -84,6 +84,27 @@ final class MessengerExtensionTest extends TestCase
         );
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testHandlerWithUnionTypeHandlesMultipleMessages(): void
+    {
+        $container = $this->getContainer(__DIR__ . '/handlerWithUnionArgumentType.neon');
+
+        $messageBus = $container->getService('messenger.default.bus');
+        assert($messageBus instanceof MessageBusInterface);
+
+        $this->assertResultsAreSame(
+            ['the result'],
+            $messageBus->dispatch(new Message())
+        );
+
+        $this->assertResultsAreSame(
+            ['the result'],
+            $messageBus->dispatch(new Message2())
+        );
+    }
+
     public function testSingleHandlerHandlesMultipleMessages(): void
     {
         $container = $this->getContainer(__DIR__ . '/messageSubscribers.neon');
@@ -214,6 +235,16 @@ final class MessengerExtensionTest extends TestCase
     }
 
     /**
+     * @requires PHP >= 8.0
+     */
+    public function testHandlerWithInvalidUnionArgumentTypeThrowException(): void
+    {
+        $this->expectException(InvalidHandlerService::class);
+
+        $this->getContainer(__DIR__ . '/invalidHandler.invalidUnionArgumentType.neon');
+    }
+
+    /**
      * @return string[][]
      */
     public function dataInvalidHandlerConfigs(): array
@@ -242,8 +273,8 @@ final class MessengerExtensionTest extends TestCase
 
         $panel = $container->getByType(MessengerPanel::class);
 
-        $this->assertRegExp('~2\+1 messages~', $panel->getTab());
-        $this->assertRegExp('~Handled messages~', $panel->getPanel());
+        $this->assertMatchesRegularExpression('~2\+1 messages~', $panel->getTab());
+        $this->assertMatchesRegularExpression('~Handled messages~', $panel->getPanel());
     }
 
     public function testLogToPanelMiddlewareIsNotRegisteredIfPanelIsDisabled(): void

--- a/tests/DI/handlerWithUnionArgumentType.neon
+++ b/tests/DI/handlerWithUnionArgumentType.neon
@@ -1,0 +1,7 @@
+messenger:
+    buses:
+        default:
+
+services:
+    - factory: Fixtures\HandlerWithUnionArgumentType('the result')
+      tags: [messenger.messageHandler]

--- a/tests/DI/invalidHandler.invalidUnionArgumentType.neon
+++ b/tests/DI/invalidHandler.invalidUnionArgumentType.neon
@@ -1,0 +1,7 @@
+messenger:
+    buses:
+        default:
+
+services:
+    - factory: Fixtures\HandlerWithInvalidUnionArgumentType
+      tags: [messenger.messageHandler]

--- a/tests/DI/messageSubscribers.withBusOption.neon
+++ b/tests/DI/messageSubscribers.withBusOption.neon
@@ -1,0 +1,8 @@
+messenger:
+    buses:
+        default:
+        other:
+
+services:
+    - Fixtures\CallableMessageSubscriber
+    - Fixtures\MessageSubscriberWithBusOption

--- a/tests/DI/messageSubscribers.withFromTransportOption.neon
+++ b/tests/DI/messageSubscribers.withFromTransportOption.neon
@@ -1,0 +1,11 @@
+messenger:
+    buses:
+        default:
+    transports:
+        memory1: in-memory://a
+        memory2: in-memory://b
+    routing:
+        Fixtures\Message: [memory1, memory2]
+
+services:
+    - Fixtures\MessageSubscriberWithFromTransportOption

--- a/tests/DI/messageSubscribers.withPriorityOption.neon
+++ b/tests/DI/messageSubscribers.withPriorityOption.neon
@@ -1,0 +1,7 @@
+messenger:
+    buses:
+        default:
+
+services:
+    - Fixtures\CallableMessageSubscriber
+    - Fixtures\MessageSubscriberWithPriorityOption

--- a/tests/DI/multipleHandlersWithFromTransport.neon
+++ b/tests/DI/multipleHandlersWithFromTransport.neon
@@ -1,0 +1,15 @@
+messenger:
+    buses:
+        default:
+    transports:
+        memory1: in-memory://a
+        memory2: in-memory://b
+    routing:
+        Fixtures\Message: [memory1, memory2]
+
+services:
+    -
+        factory: Fixtures\Handler('message from memory1 transport result')
+        tags:
+            messenger.messageHandler:
+                from_transport: memory1

--- a/tests/DI/multipleHandlersWithHandlesAndMethod.neon
+++ b/tests/DI/multipleHandlersWithHandlesAndMethod.neon
@@ -1,0 +1,16 @@
+messenger:
+    buses:
+        default:
+
+services:
+    -
+        factory: Fixtures\HandlerWithNamedMethods('result from handleWithArgumentType()')
+        tags:
+            messenger.messageHandler:
+                method: handleWithArgumentType
+    -
+        factory: Fixtures\HandlerWithNamedMethods('result from handleWithoutArgumentType()')
+        tags:
+            messenger.messageHandler:
+                method: handleWithoutArgumentType
+                handles: Fixtures\Message

--- a/tests/DI/multipleHandlersWithPriority.neon
+++ b/tests/DI/multipleHandlersWithPriority.neon
@@ -1,0 +1,18 @@
+messenger:
+    buses:
+        default:
+
+services:
+    -
+        factory: Fixtures\Handler('result with priority -10')
+        tags:
+            messenger.messageHandler:
+                priority: -10
+    -
+        factory: Fixtures\Handler('result with the default priority')
+        tags: [messenger.messageHandler]
+    -
+        factory: Fixtures\Handler('result with priority +10')
+        tags:
+            messenger.messageHandler:
+                priority: 10

--- a/tests/fixtures/HandlerWithInvalidUnionArgumentType.php
+++ b/tests/fixtures/HandlerWithInvalidUnionArgumentType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+final class HandlerWithInvalidUnionArgumentType
+{
+    public function __invoke(int|string $message): void
+    {
+    }
+}

--- a/tests/fixtures/HandlerWithNamedMethods.php
+++ b/tests/fixtures/HandlerWithNamedMethods.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 
 use function sprintf;
 
-class HandlerWithNamedMethods
+final class HandlerWithNamedMethods
 {
     private string $result;
 

--- a/tests/fixtures/HandlerWithNamedMethods.php
+++ b/tests/fixtures/HandlerWithNamedMethods.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+class HandlerWithNamedMethods
+{
+    private string $result;
+
+    public function __construct(string $result)
+    {
+        $this->result = $result;
+    }
+
+    public function handleWithArgumentType(Message $message): ?string
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param mixed $message
+     */
+    public function handleWithoutArgumentType($message): ?string
+    {
+        if (! $message instanceof Message) {
+            throw new InvalidArgumentException(sprintf(
+                'Message must be an instance of %s.',
+                Message::class
+            ));
+        }
+
+        return $this->result;
+    }
+}

--- a/tests/fixtures/HandlerWithUnionArgumentType.php
+++ b/tests/fixtures/HandlerWithUnionArgumentType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Fixtures;
 
-class Handler
+final class HandlerWithUnionArgumentType
 {
     private bool $called = false;
 
@@ -15,7 +15,7 @@ class Handler
         $this->result = $result;
     }
 
-    public function __invoke(Message $message): ?string
+    public function __invoke(Message|Message2 $message): ?string
     {
         $this->called = true;
 

--- a/tests/fixtures/MessageSubscriberWithBusOption.php
+++ b/tests/fixtures/MessageSubscriberWithBusOption.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+
+final class MessageSubscriberWithBusOption implements MessageSubscriberInterface
+{
+    /**
+     * @return iterable<string, array{method: string, bus: string}>
+     */
+    public static function getHandledMessages(): iterable
+    {
+        yield Message::class => [
+            'method' => 'handleMessage',
+            'bus' => 'other',
+        ];
+    }
+
+    public function handleMessage(Message $message): string
+    {
+        return 'message with bus option result';
+    }
+}

--- a/tests/fixtures/MessageSubscriberWithFromTransportOption.php
+++ b/tests/fixtures/MessageSubscriberWithFromTransportOption.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+
+final class MessageSubscriberWithFromTransportOption implements MessageSubscriberInterface
+{
+    /**
+     * @return iterable<string, array{method: string, from_transport: string}>
+     */
+    public static function getHandledMessages(): iterable
+    {
+        yield Message::class => [
+            'method' => 'handleMessageFromMemory1Transport',
+            'from_transport' => 'memory1',
+        ];
+    }
+
+    public function handleMessageFromMemory1Transport(Message $message): string
+    {
+        return 'message from memory1 transport result';
+    }
+}

--- a/tests/fixtures/MessageSubscriberWithPriorityOption.php
+++ b/tests/fixtures/MessageSubscriberWithPriorityOption.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures;
+
+use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+
+final class MessageSubscriberWithPriorityOption implements MessageSubscriberInterface
+{
+    /**
+     * @return iterable<string, array{method: string, priority: int}>
+     */
+    public static function getHandledMessages(): iterable
+    {
+        yield Message::class => [
+            'method' => 'handleMessage',
+            'priority' => 10,
+        ];
+    }
+
+    public function handleMessage(Message $message): string
+    {
+        return 'message with higher priority result';
+    }
+}


### PR DESCRIPTION
Added support for all handler options according to the Symfony [documentation](https://symfony.com/doc/current/messenger.html#manually-configuring-handlers).

```neon
# ...
tags:
    messenger.messageHandler:
        # currently supported:
        bus: bus_name
        alias: alias_name
        
        # newly supported:
        priority: 10
        method: myHandleMethod
        handles: App\MyMessage
        from_transport: async
```

```php

final class MyMessageSubscriber implements MessageSubscriberInterface
{
    public static function getHandledMessages(): iterable
    {
        yield MyMessage::class => [
            # currently supported:
            'method' => 'myHandleMethod',
            
            # newly supported:
            'priority' => 10,
            'bus' => 'bus_name',
            'from_transport' => 'memory1',
        ];
    }
 }
```