### PR TITLE
Fix support for middleware as registered service

### DIFF
--- a/tests/DI/middlewares.withRegisteredServiceReference.neon
+++ b/tests/DI/middlewares.withRegisteredServiceReference.neon
@@ -1,0 +1,17 @@
+messenger:
+    buses:
+        command:
+            singleHandlerPerMessage: true
+            middleware:
+                - Fixtures\StampAddingMiddleware(Fixtures\Stamp('first command'))
+                - @registeredServiceMiddleware
+        event:
+            middleware:
+                - Fixtures\StampAddingMiddleware(Fixtures\Stamp('first event'))
+                - @registeredServiceMiddleware
+
+services:
+    # Middleware registered as a service and shared by multiple buses.
+    registeredServiceMiddleware: Fixtures\StampAddingMiddleware(Fixtures\Stamp('second registered'))
+    - class: Fixtures\Handler
+      tags: [messenger.messageHandler]


### PR DESCRIPTION
### Problem

According to the [documentation](https://github.com/fmasa/messenger/blob/ea531532c89184a7fc7a3b3008e9eda51896cab9/docs/index.md#middleware), it should be possible to specify middleware as a registered service. Something as simple as this example should work:

```neon
messenger:
    buses:
        commandBus:
            middleware:
                - MyCustomMiddleware()
                - @registeredServiceMiddleware

services:
    registeredServiceMiddleware: MyAnotherMiddleware()
```

But it currently doesn't work. Container compilation fails with `Reference to missing service 'registeredServiceMiddleware'` error:

<details>
<summary>Output of the `testAddingMiddlewareAsRegisteredService` test with the error</summary>


```
There was 1 error:

1) Fmasa\Messenger\DI\MessengerExtensionTest::testAddingMiddlewareAsRegisteredService
Nette\DI\ServiceCreationException: Service 'messenger.command.middleware.1': Reference to missing service 'registeredServiceMiddleware'.

~/symfony-messenger-nette/vendor/nette/di/src/DI/Resolver.php:385
~/symfony-messenger-nette/vendor/nette/di/src/DI/Resolver.php:368
~/symfony-messenger-nette/vendor/nette/di/src/DI/Resolver.php:104
~/symfony-messenger-nette/vendor/nette/di/src/DI/Definitions/ServiceDefinition.php:202
~/symfony-messenger-nette/vendor/nette/di/src/DI/Resolver.php:71
~/symfony-messenger-nette/vendor/nette/di/src/DI/ContainerBuilder.php:304
~/symfony-messenger-nette/vendor/nette/di/src/DI/ContainerBuilder.php:318
~/symfony-messenger-nette/vendor/nette/di/src/DI/ContainerBuilder.php:259
~/symfony-messenger-nette/src/Messenger/DI/MessengerExtension.php:111
~/symfony-messenger-nette/vendor/nette/di/src/DI/Compiler.php:241
~/symfony-messenger-nette/vendor/nette/di/src/DI/Compiler.php:211
~/symfony-messenger-nette/vendor/nette/di/src/DI/ContainerLoader.php:119
~/symfony-messenger-nette/vendor/nette/di/src/DI/ContainerLoader.php:80
~/symfony-messenger-nette/vendor/nette/di/src/DI/ContainerLoader.php:44
~/symfony-messenger-nette/vendor/nette/bootstrap/src/Bootstrap/Configurator.php:277
~/symfony-messenger-nette/vendor/nette/bootstrap/src/Bootstrap/Configurator.php:254
~/symfony-messenger-nette/tests/DI/MessengerExtensionTest.php:438
~/symfony-messenger-nette/tests/DI/MessengerExtensionTest.php:63

```

</details>

I'm not sure if I'm missing something, but I'm surprised no one pointed this problem out before. It's essential for Messenger. For example, for  [`DispatchAfterCurrentBusMiddleware`](https://symfony.com/doc/current/messenger/dispatch_after_current_bus.html) to work correctly, all buses must use the same instance of the middleware, therefore, it must be registered as a service.

### Solution

The problem is caused by how `MessengerPanel` is registered to the container: setting its arguments in `loadConfiguration`.

So the solution is to break `MessengerPanel` registration into two parts:
- First:  add  `MessengerPanel`  definition to the container builder conditionally in `loadConfiguration` (same as before)
- Second: set all registered `LogToPanelMiddleware` as its argument in `beforeCompile` (which is the [correct phase of container assembling for linking services](https://doc.nette.org/en/dependency-injection/extensions#toc-beforecompile)).

Thanks to this change, `$this->getContainerBuilder()->findByType(LogToPanelMiddleware::class)` is now called only after the container contains all services (from this extension, other extensions, and the hosting app), which allows middleware to reference registered services. 