### PR TITLE
Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"psr/container": "^1.0",
-		"symfony/event-dispatcher": "^4.4|^5.0",
-		"symfony/messenger": "^5.3",
-		"symfony/console": "^4.4|^5.0",
+		"symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+		"symfony/messenger": "^5.3|^6.0",
+		"symfony/console": "^4.4|^5.0|^6.0",
 		"nette/di": "^3.0.1",
 		"nette/schema": "^1.0.3",
 		"tracy/tracy": "^2.6"

--- a/src/Messenger/DI/MessengerExtension.php
+++ b/src/Messenger/DI/MessengerExtension.php
@@ -257,6 +257,10 @@ class MessengerExtension extends CompilerExtension
             ->setFactory(TransportFactory::class);
 
         foreach (self::DEFAULT_FACTORIES as $name => $factoryClass) {
+            if (! class_exists($factoryClass)) {
+                continue;
+            }
+
             $builder->addDefinition($this->prefix('transportFactory.' . $name))
                 ->setFactory($factoryClass)
                 ->setTags([self::TAG_TRANSPORT_FACTORY => true]);


### PR DESCRIPTION
This adds `^6.0` to allowed versions of `symfony/console`, `symfony/event-dispatcher`, and `symfony/messenger`.

None of the code changes (deprecation removals) in Symfony Messenge v6 affects this package directly: https://github.com/symfony/messenger/blob/6.1/CHANGELOG.md

However, `symfony/messenger` 6+ doesn't require  `symfony/amqp-messenger`, `symfony/doctrine-messenger`, and `symfony/redis-messenger` anymore and the DI extension has to account for it.